### PR TITLE
Spawn point logic changes

### DIFF
--- a/srunner/examples/simdaas_test_junction.osc
+++ b/srunner/examples/simdaas_test_junction.osc
@@ -27,7 +27,7 @@ scenario top:
     do serial:
         spawn: parallel(duration:20s):
             ego_vehicle.drive(path) with:
-                speed(10kph)
+                speed(0.1kph)
                 #road_action(speed:20kph,turn:straight)
                 lane(4, at: start)
             npc.drive(path) with:


### PR DESCRIPTION


<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ x] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated

-->

#### Description

Spawn points are now generated using generate_waypoints() for random spawns

junction spawns are now handled by get_waypoint_by_lane_id()

next() is being used for junction waypoints because of an issue with s=0 being confused for predecessor road/junction. The module converts waypoint to transform, then for relative vehicle position the transform is used to get waypoint. This led to the waypoint being on the wrong road as the original waypoint was for s=0. Using next() removes the issue.

<!-- Please explain the changes you made here as detailed as possible. -->


#### Where has this been tested?

  * **Platform(s):** ...Windows 10
  * **Python version(s):** ... 3.11.9
  * **Unreal Engine version(s):** ... 5.3
  * **CARLA version:** ... NA

#### Possible Drawbacks

There could be edge cases which have not been discovered yet.

<!-- What are the possible side-effects or negative impacts of the code change? -->
